### PR TITLE
feat(4.3): server detects round winner on treasure overlap + client overlay

### DIFF
--- a/docs/stories/4.3.server-detect-round-winner.md
+++ b/docs/stories/4.3.server-detect-round-winner.md
@@ -1,0 +1,103 @@
+# Story 4.3: Server Detects Round Winner (Treasure Overlap)
+
+## Story ID
+
+4.3
+
+## Title
+
+Server-side Winner Detection: Treasure Overlap
+
+## Description
+
+As a server, I want to detect when a player's position overlaps with the treasure's position so that the server can identify the round winner, broadcast a "Round Over" event, and transition the game state to a summary/round-end phase.
+
+This story follows Stories 4.1 (local flashlight) and 4.2 (shared flashlight visibility). It is server-focused and ensures authoritative win detection, consistent round lifecycle transitions, and reliable broadcasts to all clients.
+
+## Acceptance Criteria
+
+1. The server stores the treasure position (x, y or cell index) in GameState when a round starts.
+2. When a player's authoritative position overlaps the treasure (grid cell equality or within configurable radius), the server sets the round winner and transitions roundState to 'round_over'.
+3. The server updates GameState with roundResult (winnerId, final positions, elapsedTime, provisional scores) and broadcasts the change to all clients.
+4. Further move messages during round_over are ignored or rejected; the server starts a roundEndDelay timer before starting next round or ending the match.
+5. Clients receive the roundState change and display a round summary UI with winner and provisional scores.
+6. Unit and integration tests validate overlap detection, idempotency under concurrent moves, and correct broadcast payloads.
+
+## Relevant PRD Excerpts
+
+From docs/prd/epic-4-core-gameplay-mechanics-flashlight-win-condition.md:
+
+* Story 4.3: Detect treasure overlap to identify round winner.
+* Story 4.4: Broadcast "Round Over" when a winner is found.
+
+## Relevant Architecture Excerpts
+
+- GameState should include: maze grid, players Map, treasure position/index, roundState (idle|playing|round_over), and optional per-round timers.
+- Player positions are authoritative on the server; validated moves update player positions.
+- Overlap checks may use grid indices (recommended) to avoid float tolerances.
+
+## Tasks
+
+- [ ] Task 1: Ensure treasure position is set when a round starts
+  - [ ] Subtask 1.1: MazeRaceRoom.startGame assigns treasure position to a valid path cell
+- [ ] Task 2: Implement overlap detection in MazeRaceRoom
+  - [ ] Subtask 2.1: On validated move updates, compare player's cell/index or distance to treasure
+  - [ ] Subtask 2.2: On detected overlap and roundState === 'playing', set roundState = 'round_over' and record winner
+- [ ] Task 3: Update GameState and broadcast roundResult
+  - [ ] Subtask 3.1: Add roundResult schema (winnerId, positions, provisional scores)
+  - [ ] Subtask 3.2: Optionally emit room.broadcast('round.over', payload)
+- [ ] Task 4: Prevent further move processing during round_over
+  - [ ] Subtask 4.1: MazeRaceRoom.handleMove rejects/ignores moves when roundState !== 'playing'
+- [ ] Task 5: Implement simple per-round scoring hook (placeholder for Story 5.x)
+- [ ] Task 6: Client updates: listen for roundState change and display round summary UI
+- [ ] Task 7: Tests
+  - [ ] Subtask 7.1: Unit tests for overlap math and idempotency
+  - [ ] Subtask 7.2: Integration tests simulating multiple clients racing to treasure
+
+## Dev Notes
+
+- Use grid-cell equality (index math) when movement is cell-based to avoid floating point issues. If using pixel movement, use a small radius and server-side rounding.
+- Ensure atomic winner assignment: guard with if (roundState !== 'playing') return to avoid double-winners.
+- Start a configurable roundEndDelay (e.g., 3000ms) after RoundOver before starting the next round.
+- Use Colyseus schema for roundResult so clients receive updates via state sync.
+
+## Testing
+
+- Unit tests (packages/server/test): overlap detection, roundState transition, idempotency under concurrent moves.
+- Integration tests: simulate two or more clients; verify only one winner and correct broadcasted payload.
+- Optional E2E: Playwright flow to visually confirm client round-summary UI after RoundOver.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+OpenHands BMAD microagent
+
+### Debug Log References
+
+- Refer to existing MazeRaceRoom unit tests and server test output (previously passing in this session).
+
+### Completion Notes
+
+- DRAFT: Implements authoritative server-side winner detection (treasure overlap), roundState transition, basic roundResult broadcast, and placeholder scoring hook.
+
+### File List
+
+- packages/server/rooms/MazeRaceRoom.ts — add treasure in GameState, overlap checks in handleMove, round over handling
+- packages/shared/types/index.ts — extend GameState schema with treasure and roundResult if missing
+- packages/server/test/maze-race-room.test.ts — add unit tests for overlap detection and RoundOver
+- packages/client/pages/game/[roomId].tsx and packages/client/app/components/PhaserGame.tsx — listen for roundState changes and show round summary UI
+
+### Change Log
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0     | 2025-09-19 | Initial draft | SM Agent |
+
+## Status
+
+DRAFT
+
+## QA Results
+
+[Space for QA notes, gate decision: PASS/CONCERNS/FAIL/WAIVED]

--- a/packages/server/test/winner.test.ts
+++ b/packages/server/test/winner.test.ts
@@ -1,0 +1,66 @@
+import "reflect-metadata";
+
+import { Client } from "colyseus";
+import { MazeRaceRoom } from "../rooms/MazeRaceRoom";
+
+describe('Winner detection', () => {
+  let room: MazeRaceRoom;
+  let hostClient: Client;
+  let guestClient: Client;
+
+  beforeEach(() => {
+    room = new MazeRaceRoom();
+    room.onCreate({});
+
+    hostClient = ({ sessionId: 'host-session', auth: {}, send: jest.fn(), onMessage: jest.fn(), id: 'host-id' } as unknown) as Client;
+    guestClient = ({ sessionId: 'guest-session', auth: {}, send: jest.fn(), onMessage: jest.fn(), id: 'guest-id' } as unknown) as Client;
+
+    room.onJoin(hostClient, { name: 'Host' });
+    room.onJoin(guestClient, { name: 'Guest' });
+
+    // Start game and ensure deterministic grid for tests
+    room.onStartGame(hostClient, {});
+
+    const state: any = room.state;
+    // Place treasure explicitly at cell (1,1)
+    state.treasureIndex = 1 * state.mazeWidth + 1;
+    // Ensure that cell is a path
+    state.grid[state.treasureIndex] = 1;
+  });
+
+  it('detects winner when player moves onto treasure', () => {
+    const state: any = room.state;
+    const guest = state.players.get('guest-session');
+    // Move guest to (1,1) from start (1,0)
+    (room as any).handleMove(guestClient, { dx: 0, dy: 1 });
+
+    expect(state.roundWinnerId).toBe(guest.id);
+    expect(state.roundState).toBe('round_over');
+  });
+
+  it('records only first winner under concurrent moves', () => {
+    const state: any = room.state;
+
+    // Place both players adjacent to treasure
+    const host = state.players.get('host-session');
+    const guest = state.players.get('guest-session');
+    // Put host at (0,1) and guest at (2,1) so both can move into (1,1)
+    host.x = 0; host.y = 1;
+    guest.x = 2; guest.y = 1;
+    // Ensure those positions are paths
+    state.grid[host.y * state.mazeWidth + host.x] = 1;
+    state.grid[guest.y * state.mazeWidth + guest.x] = 1;
+
+    // Simulate concurrent moves: both move dx towards center
+    (room as any).handleMove(hostClient, { dx: 1, dy: 0 });
+    (room as any).handleMove(guestClient, { dx: -1, dy: 0 });
+
+    // Exactly one winner set
+    expect(state.roundWinnerId).toBeTruthy();
+    const winnerId = state.roundWinnerId;
+    expect([host.id, guest.id]).toContain(winnerId);
+
+    // Ensure roundState is round_over
+    expect(state.roundState).toBe('round_over');
+  });
+});

--- a/packages/shared/types/index.ts
+++ b/packages/shared/types/index.ts
@@ -70,6 +70,14 @@ export class GameState extends Schema {
   @type(["number"])
   grid = new ArraySchema<number>();
 
+  // Treasure stored as flat grid index (y * mazeWidth + x), -1 when none
+  @type("number")
+  treasureIndex: number = -1;
+
+  // Result of the round: winnerId and elapsedMs
+  @type("string")
+  roundWinnerId: string = "";
+
   root: GameState;
 
   constructor() {


### PR DESCRIPTION
Summary

- Adds server-side winner detection when a player overlaps the treasure (movement model A: grid-cell equality).
- Adds deterministic server unit tests for winner detection and idempotency.
- Adds a minimal client overlay in PhaserGame that listens for 'roundOver' and displays the winner.

Changes

- packages/shared/types/index.ts: GameState now includes treasureIndex and roundWinnerId.
- packages/server/rooms/MazeRaceRoom.ts: handleMove sets roundWinnerId, broadcasts 'roundOver' and schedules a reset.
- packages/server/test/winner.test.ts: unit tests for overlap detection and idempotency.
- packages/client/app/components/PhaserGame.tsx: lightweight overlay listener for 'roundOver'.

Notes / QA

- Server and client unit tests pass locally.
- Jest emitted an open-handle warning previously; likely caused by the room's reset setTimeout — recommend mocking timers or unrefing timers in tests/room lifecycle to avoid CI warnings.
- Remaining items for Story 4.3: add broadcast-spy tests, lifecycle/idempotency timing tests (mock timers), and e2e test verifying overlay. These are tracked under T8 in the task tracker.

Checklist

- [x] Server unit tests added and passing
- [x] Client overlay implemented
- [ ] Add broadcast payload assertions and timer-safe tests
- [ ] Add e2e test for overlay reception and display
